### PR TITLE
Fix/remove compiled resources

### DIFF
--- a/SentinelHub/__init__.py
+++ b/SentinelHub/__init__.py
@@ -29,8 +29,6 @@ def classFactory(iface):
     # pylint: disable=import-outside-toplevel
     # pylint: disable=unused-import
 
-    # The following initializes UI
-    from . import resources
     from .utils.meta import ensure_import
 
     ensure_import("defusedxml")

--- a/SentinelHub/main.py
+++ b/SentinelHub/main.py
@@ -77,7 +77,7 @@ class SentinelHubPlugin:
 
     # pylint: disable=too-many-public-methods
 
-    ICON_PATH = ":/plugins/SentinelHub/favicon.ico"
+    ICON_PATH = os.path.join(os.path.dirname(__file__), "favicon.ico")
 
     def __init__(self, iface):
         """Called by QGIS at the beginning when you open QGIS or when the plugin is enabled in the

--- a/SentinelHub/metadata.txt
+++ b/SentinelHub/metadata.txt
@@ -6,7 +6,7 @@ name=SentinelHub
 qgisMinimumVersion=3.22
 qgisMaximumVersion=4.99
 description=SentinelHub plugin enables users to harness the power of Sentinel Hub services directly from QGIS.
-version=2.0.7
+version=2.0.8
 author=Sinergise
 email=info@sentinel-hub.com
 
@@ -26,8 +26,8 @@ repository=https://github.com/sentinel-hub/sentinelhub-qgis-plugin
 
 # Recommended items:
 changelog=
-    2.0.7
-        - Revert 2.0.6, which introduced an import regression that prevented the plugin from loading
+    2.0.8
+        - Fix plugin failing to load on QGIS 4 / Qt6: drop the compiled Qt resource (which hardcoded a PyQt5 import) and load the toolbar icon directly from file
     2.0.5
         - Use defusedxml for parsing XML responses to address security scanner findings
     2.0.4

--- a/SentinelHub/metadata.txt
+++ b/SentinelHub/metadata.txt
@@ -27,7 +27,7 @@ repository=https://github.com/sentinel-hub/sentinelhub-qgis-plugin
 # Recommended items:
 changelog=
     2.0.8
-        - Fix plugin failing to load on QGIS 4 / Qt6: drop the compiled Qt resource (which hardcoded a PyQt5 import) and load the toolbar icon directly from file
+        - Fix plugin failing to load on QGIS 4 / Qt6: drop the compiled Qt resource and load the toolbar icon directly from file
     2.0.5
         - Use defusedxml for parsing XML responses to address security scanner findings
     2.0.4

--- a/SentinelHub/pb_tool.cfg
+++ b/SentinelHub/pb_tool.cfg
@@ -26,7 +26,7 @@ main_dialog: dockwidget.ui
 compiled_ui_files:
 
 # Resource file(s) that will be compiled
-resource_files: resources.qrc
+resource_files:
 
 # Other files required for the plugin
 extras:

--- a/SentinelHub/resources.qrc
+++ b/SentinelHub/resources.qrc
@@ -1,5 +1,0 @@
-<RCC>
-    <qresource prefix="/plugins/SentinelHub" >
-        <file>favicon.ico</file>
-    </qresource>
-</RCC>


### PR DESCRIPTION
Compiling Qt resource bundle led to a situation where the autogen file contained hardcoded `PyQt5` import: `pb_tool` used `pyrcc5` underneath. 

Not sure why this was compiled in the first place (it only contained `favicon.ico` anyway), after removing it and checking on all three major platforms, both `3.x LTS` and `4.x` versions worked fine.